### PR TITLE
Fix warning by implementing -placeholder

### DIFF
--- a/CSNPlaceholderTextView/CSNPlaceholderTextView.m
+++ b/CSNPlaceholderTextView/CSNPlaceholderTextView.m
@@ -82,6 +82,10 @@
     [self updatePlaceholderLabelVisibility];
 }
 
+- (NSString *)placeholder
+{
+    return self.placeholderLabel.text;
+}
 - (void)setPlaceholder:(NSString *)placeholder
 {
     self.placeholderLabel.text = placeholder;


### PR DESCRIPTION
Before it would always return nil. Decent build settings under newer
versions of Xcode even warn about this.
