### PR TITLE
Position placeholder behind insertion marker

### DIFF
--- a/CSNPlaceholderTextView/CSNPlaceholderTextView.m
+++ b/CSNPlaceholderTextView/CSNPlaceholderTextView.m
@@ -50,7 +50,8 @@
 
 - (void)commonInit
 {
-    [self addSubview:self.placeholderLabel];
+    // Insert as first subview so appears below the insertion marker etc.
+    [self insertSubview:self.placeholderLabel atIndex:0];
     self.placeholderLabel.hidden = YES;
 }
 


### PR DESCRIPTION
Presently under iOS 7, if you look closely you can see the placeholder sits atop the insertion marker.
